### PR TITLE
Fix new_content for Python3

### DIFF
--- a/django_resized/forms.py
+++ b/django_resized/forms.py
@@ -6,7 +6,7 @@ except ImportError:
 
 try:
     # python3
-    from io import StringIO
+    from io import BytesIO as StringIO
 except ImportError:
     # python2
     from StringIO import StringIO


### PR DESCRIPTION
In Python3 we would get `'string argument expected, got 'bytes' instead` if we're using StringIO. 
For forward compatibility BytesIO is recommended.

P.S this fixes image uploading.