### PR TITLE
Normalize orientation from meta data

### DIFF
--- a/django_resized/forms.py
+++ b/django_resized/forms.py
@@ -21,14 +21,19 @@ def normalize_rotation(image):
     Find orientation header and rotate the actual data instead.
     Adapted from http://stackoverflow.com/a/6218425/723090
     """
+    try:
+        image._getexif()
+    except AttributeError:
+        """ No exit data; this image is not a jpg and can be skipped. """
+        return image
     for orientation in ExifTags.TAGS.keys():
-        """ Look for orientation header, stop when found """
+        """ Look for orientation header, stop when found. """
         if ExifTags.TAGS[orientation] == 'Orientation':
             break
     else:
-        """ No orientation header found, do nothing """
+        """ No orientation header found, do nothing. """
         return image
-    """ Apply the different possible orientations to the data; preserve format """
+    """ Apply the different possible orientations to the data; preserve format. """
     format = image.format
     action_nr = image._getexif()[orientation]
     if action_nr == 3:

--- a/django_resized/forms.py
+++ b/django_resized/forms.py
@@ -31,7 +31,6 @@ def normalize_rotation(image):
     """ Apply the different possible orientations to the data; preserve format """
     format = image.format
     action_nr = image._getexif()[orientation]
-    #exif = dict(image._getexif().items())
     if action_nr == 3:
         image = image.rotate(180, expand=True)
     elif action_nr == 6:

--- a/django_resized/forms.py
+++ b/django_resized/forms.py
@@ -1,7 +1,7 @@
 import os
 import sys
 from io import BytesIO
-from PIL import Image, ImageFile, ImageOps
+from PIL import Image, ImageFile, ImageOps, ExifTags
 from django.conf import settings
 from django.core.files.base import ContentFile
 
@@ -16,11 +16,39 @@ DEFAULT_QUALITY = getattr(settings, 'DJANGORESIZED_DEFAULT_QUALITY', 0)
 DEFAULT_KEEP_META = getattr(settings, 'DJANGORESIZED_DEFAULT_KEEP_META', True)
 
 
+def normalize_rotation(image):
+    """
+    Find orientation header and rotate the actual data instead.
+    Adapted from http://stackoverflow.com/a/6218425/723090
+    """
+    for orientation in ExifTags.TAGS.keys():
+        """ Look for orientation header, stop when found """
+        if ExifTags.TAGS[orientation] == 'Orientation':
+            break
+    else:
+        """ No orientation header found, do nothing """
+        return image
+    """ Apply the different possible orientations to the data; preserve format """
+    format = image.format
+    action_nr = image._getexif()[orientation]
+    #exif = dict(image._getexif().items())
+    if action_nr == 3:
+        image = image.rotate(180, expand=True)
+    elif action_nr == 6:
+        image = image.rotate(270, expand=True)
+    elif action_nr == 8:
+        image = image.rotate(90, expand=True)
+    image.format = format
+    return image
+
+
 class ResizedImageFieldFile(ImageField.attr_class):
 
     def save(self, name, content, save=True):
         content.file.seek(0)
         img = Image.open(content.file)
+
+        img = normalize_rotation(img)
 
         if not self.field.keep_meta:
             image_without_exif = Image.new(img.mode, img.size)


### PR DESCRIPTION
I've been having trouble with uploaded jpg pictures having the wrong orientation (in Firefox). This is due to some cameras storing orientation in exif tags, which isn't handled correctly by PIL. As an example, with the attached image:

```
from PIL import Image, ExifTags

def normalize_rotation(image):
    """
    Find orientation header and rotate the actual data instead.
    Adapted from http://stackoverflow.com/a/6218425/723090
    """
    try:
        image._getexif()
    except AttributeError:
        """ No exit data; this image is not a jpg and can be skipped. """
        return image
    for orientation in ExifTags.TAGS.keys():
        """ Look for orientation header, stop when found. """
        if ExifTags.TAGS[orientation] == 'Orientation':
            break
    else:
        """ No orientation header found, do nothing. """
        return image
    """ Apply the different possible orientations to the data; preserve format. """
    format = image.format
    action_nr = image._getexif()[orientation]
    if action_nr == 3:
        image = image.rotate(180, expand=True)
    elif action_nr == 6:
        image = image.rotate(270, expand=True)
    elif action_nr == 8:
        image = image.rotate(90, expand=True)
    image.format = format
    return image

img = Image.open('cny.jpg')
img2 = normalize_rotation(img)

img.save('cny_nofix.jpg')
img2.save('cny_fix.jpg')
```

Multiple programs (all?) show cny_fix.jpg with the correct orientation but cny_nofix.jpg as being rotated 90 degrees (counter-clockwise) as compared to the input file. Not desirable.

The solution is to find the rotation header that PIL ignored, and manually apply the rotation to the actual data. This is what `normalize_rotation` does (and some handling of special cases, making it look more complicated than it is).

I've tested it on Python 2.7 and 3.4 with jpg and png images (png images don't have this problem, but just to be sure it doesn't crash).

![cny](https://cloud.githubusercontent.com/assets/6442863/11010564/f890940a-84df-11e5-9173-0c6c5470fd23.jpg)
