### PR TITLE
Remove EXIF information without creating new image

### DIFF
--- a/django_resized/forms.py
+++ b/django_resized/forms.py
@@ -81,7 +81,7 @@ class ResizedImageFieldFile(ImageField.attr_class):
 
         img_info = img.info
         if not self.field.keep_meta:
-            img_info.pop('exif')
+            img_info.pop('exif', None)
 
         ImageFile.MAXBLOCK = max(ImageFile.MAXBLOCK, thumb.size[0] * thumb.size[1])
         new_content = BytesIO()

--- a/django_resized/forms.py
+++ b/django_resized/forms.py
@@ -79,16 +79,14 @@ class ResizedImageFieldFile(ImageField.attr_class):
             )
             thumb = img
 
+        img_info = img.info
         if not self.field.keep_meta:
-            thumb_without_exif = Image.new(thumb.mode, thumb.size)
-            thumb_without_exif.putdata(thumb.getdata())
-            thumb_without_exif.format = thumb.format
-            thumb = thumb_without_exif
+            img_info.pop('exif')
 
         ImageFile.MAXBLOCK = max(ImageFile.MAXBLOCK, thumb.size[0] * thumb.size[1])
         new_content = BytesIO()
         img_format = img.format if self.field.force_format is None else self.field.force_format
-        thumb.save(new_content, format=img_format, quality=self.field.quality, **img.info)
+        thumb.save(new_content, format=img_format, quality=self.field.quality, **img_info)
         new_content = ContentFile(new_content.getvalue())
 
         name = self.get_name(name, img_format)

--- a/django_resized/forms.py
+++ b/django_resized/forms.py
@@ -65,12 +65,6 @@ class ResizedImageFieldFile(ImageField.attr_class):
         if DEFAULT_NORMALIZE_ROTATION:
             img = normalize_rotation(img)
 
-        if not self.field.keep_meta:
-            image_without_exif = Image.new(img.mode, img.size)
-            image_without_exif.putdata(img.getdata())
-            image_without_exif.format = img.format
-            img = image_without_exif
-
         if self.field.crop:
             thumb = ImageOps.fit(
                 img,
@@ -84,6 +78,12 @@ class ResizedImageFieldFile(ImageField.attr_class):
                 Image.ANTIALIAS,
             )
             thumb = img
+
+        if not self.field.keep_meta:
+            thumb_without_exif = Image.new(thumb.mode, thumb.size)
+            thumb_without_exif.putdata(thumb.getdata())
+            thumb_without_exif.format = thumb.format
+            thumb = thumb_without_exif
 
         ImageFile.MAXBLOCK = max(ImageFile.MAXBLOCK, thumb.size[0] * thumb.size[1])
         new_content = BytesIO()


### PR DESCRIPTION
Thanks for great library. 
# Problem
We are having one problem when images are very big. To remove EXIF information from image we need to create new image by calling `Image.new`. This takes a lot of time for big images. 
# Solution
Do not open image to remove exif information. `img.info` holds EXIF meta data and we can remove it. 