### PR TITLE
Force Format Change

### DIFF
--- a/django_resized/forms.py
+++ b/django_resized/forms.py
@@ -64,7 +64,11 @@ class ResizedImageFieldFile(ImageField.attr_class):
 
         if DEFAULT_NORMALIZE_ROTATION:
             img = normalize_rotation(img)
-
+            
+        if self.field.force_format == 'JPEG' or 'JPG' or 'jpeg' or 'jpg':
+           if img.mode != 'RGB':
+               img = img.convert('RGB')
+                
         if self.field.crop:
             thumb = ImageOps.fit(
                 img,


### PR DESCRIPTION
The current force_format functionality in the code simply changes the file extension. This is not good when a user uploads a large PNG and you require to save a much more compressed JPG. This edit flattens RGBA images into RGB if force_format is set to JPEG, JPG, jpeg or jpg.