### PR TITLE
Fix error when force_format=JPEG are passed

### DIFF
--- a/django_resized/forms.py
+++ b/django_resized/forms.py
@@ -65,6 +65,9 @@ class ResizedImageFieldFile(ImageField.attr_class):
         if DEFAULT_NORMALIZE_ROTATION:
             img = normalize_rotation(img)
 
+        if self.field.force_format.lower() in ('jpeg', 'jpg') and img.mode != 'RGB':
+            img = img.convert('RGB')
+
         if self.field.crop:
             thumb = ImageOps.fit(
                 img,


### PR DESCRIPTION
Issue https://github.com/un1t/django-resized/issues/19 still actual, so based on https://github.com/un1t/django-resized/issues/25 I've created new PR to fix it.
