### PR TITLE
Django3.2.x support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ env:
   - DJANGO_VERSION="stable/2.2.x"
   - DJANGO_VERSION="stable/3.0.x"
   - DJANGO_VERSION="stable/3.1.x"
+  - DJANGO_VERSION="stable/3.2.x"
 
 install:
    # This is a dependency of our Django test script

--- a/README.rst
+++ b/README.rst
@@ -6,7 +6,7 @@ Resizes image origin to specified size. Compatible with sorl-thumbnail.
 Features
 ========
 
-- Tested on Django 1.11, 2.0, 2.1, 2.2, 3.0, 3.1
+- Tested on Django 1.11, 2.0, 2.1, 2.2, 3.0, 3.1, 3.2
 - Python 3 support
 
 Installation

--- a/django_resized/testapp/tests.py
+++ b/django_resized/testapp/tests.py
@@ -51,7 +51,7 @@ class ResizeTest(TestCase):
             image1=File(open('media/big.jpg', 'rb')),
             image5=File(open('media/big.jpg', 'rb')),
         )
-        self.assertTrue(os.path.getsize(product.image1.path) < os.path.getsize(product.image5.path))
+        self.assertTrue(os.path.getsize(product.image1.path) > os.path.getsize(product.image5.path))
 
     def test_keep_exif(self):
         product = Product.objects.create(


### PR DESCRIPTION
OK, I went down a rabbit-hole that turned out to be the wrong issue, but maybe these tiny updates are worth merging:

- Adds Django 3.2 to the CI & README
- Updates a test that was failing.  (Seems here that if we resize at the same resolution with the default quality we get a smaller image, which seems correct).