### PR TITLE
Add "png" to the formats that need the img mode to be RGB

### DIFF
--- a/django_resized/forms.py
+++ b/django_resized/forms.py
@@ -66,7 +66,8 @@ class ResizedImageFieldFile(ImageField.attr_class):
         if DEFAULT_NORMALIZE_ROTATION:
             img = normalize_rotation(img)
 
-        if self.field.force_format and self.field.force_format.lower() in ('jpeg', 'jpg') and img.mode != 'RGB':
+        rgb_formats = ('jpeg', 'jpg', 'png')
+        if self.field.force_format and self.field.force_format.lower() in rgb_formats and img.mode != 'RGB':
             img = img.convert('RGB')
 
         if self.field.crop:


### PR DESCRIPTION
I will link an issue to this PR. But here is the issue:

I receive the error "OSError: cannot write mode CMYK as PNG" everytime I try to save a image with CMYK mode.
(I use "PNG" as the "DJANGORESIZED_DEFAULT_FORCE_FORMAT")

Digging into the source code I wonder why would only JPEG and JPG be the ones that can benefit from automatic conversion to RGB when it would be advantageous to PNG as well.

If I misunderstood something, please, let me know!
Thanks for the lib.