### PR TITLE
 Add 'png' to the formats that need the img mode to be RGBA

### DIFF
--- a/django_resized/forms.py
+++ b/django_resized/forms.py
@@ -66,9 +66,12 @@ class ResizedImageFieldFile(ImageField.attr_class):
         if DEFAULT_NORMALIZE_ROTATION:
             img = normalize_rotation(img)
 
-        rgb_formats = ('jpeg', 'jpg', 'png')
+        rgb_formats = ('jpeg', 'jpg')
+        rgba_formats = ('png')
         if self.field.force_format and self.field.force_format.lower() in rgb_formats and img.mode != 'RGB':
             img = img.convert('RGB')
+        if self.field.force_format and self.field.force_format.lower() in rgba_formats and img.mode != 'RGBA':
+            img = img.convert('RGBA')
 
         if self.field.crop:
             thumb = ImageOps.fit(


### PR DESCRIPTION
Using rgba for keeping transparency mask when force_format is 'png'