### PR TITLE
Add support for django 4.2 and python 3.11-3.12

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -11,8 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        django_version: [ '3.2', '4.0', '4.1' ]
-        python_version: [ '3.7', '3.8', '3.9', '3.10' ]
+        django_version: [ '3.2', '4.0', '4.1', '4.2' ]
+        python_version: [ '3.7', '3.8', '3.9', '3.10', '3.11', '3.12' ]
         exclude:
 
           - django_version: '4.0'
@@ -20,17 +20,26 @@ jobs:
 
           - django_version: '4.1'
             python_version: '3.7'
+
+          - django_version: '4.2'
+            python_version: '3.7'
+
+          - django_version: '3.2'
+            python_version: '3.12'
+
+          - django_version: '3.2'
+            python_version: '3.11'
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python_version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python_version }}
     - name: Cache pip
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         # This path is specific to Ubuntu
         path: ~/.cache/pip

--- a/django_resized/tests/settings.py
+++ b/django_resized/tests/settings.py
@@ -1,6 +1,6 @@
-import os
+from pathlib import Path
 
-BASE_DIR = os.path.dirname(os.path.dirname(__file__))
+BASE_DIR = Path(__file__).parent.parent
 
 SECRET_KEY = 'secret'
 
@@ -37,7 +37,7 @@ INSTALLED_APPS = (
     'django.contrib.sessions',
     'django.contrib.admin',
     'django.contrib.messages',
-    'django_resized',
+    'django_resized.tests',
 )
 
 TEMPLATES = [
@@ -64,4 +64,4 @@ USE_TZ = False
 
 DJANGORESIZED_DEFAULT_SIZE = [400, 300]
 
-MEDIA_ROOT = os.path.join(BASE_DIR, 'media')
+MEDIA_ROOT = BASE_DIR / 'media'

--- a/setup.py
+++ b/setup.py
@@ -5,8 +5,6 @@
 #
 #  django-resized is free software under terms of the MIT License.
 #
-
-import os
 from setuptools import setup, find_packages
 
 
@@ -14,7 +12,7 @@ setup(
     name     = 'django-resized',
     version  = '1.0.3dev',
     packages = ['django_resized'],
-    requires = ['python (>= 2.7)', 'django (>= 1.7)'],
+    requires = ['python (>= 3.7)', 'django (>= 1.7)'],
     description  = 'Resizes image origin to specified size.',
     long_description = open('README.rst').read(),
     author       = 'Ilya Shalyapin',
@@ -26,11 +24,19 @@ setup(
     classifiers  = [
         'Environment :: Web Environment',
         'Framework :: Django',
+        'Framework :: Django :: 3.2',
+        'Framework :: Django :: 4.1',
+        'Framework :: Django :: 4.0',
+        'Framework :: Django :: 4.2',
         'Intended Audience :: Developers',
+        'License :: OSI Approved :: MIT License',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
     ],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,22 +1,20 @@
 [tox]
 skipsdist = True
 envlist =
-    {py36}-django-{32}
-    {py37}-django-{32}
-    {py38}-django-{32,40,41}
-    {py39}-django-{32,40,41}
-    {py310}-django-{32,40,41}
-    {py38}-flake8
+    py{37,38,39,310}-django-{32}
+    py{38,39,310,311,312}-django-{40,41,42}
+    py310-flake8
 
 [testenv]
 setenv =
     PYTHONPATH = {toxinidir}:{toxinidir}
 deps =
     -rdjango_resized/tests/requirements.txt
-    py38-flake8: flake8>=3.0,<4.0
+    py310-flake8: flake8
     django-32: Django>=3.2,<4.0
     django-40: Django>=4.0,<4.1
     django-41: Django>=4.1,<4.2
+    django-42: Django>=4.2,<4.3
 commands =
-    flake8: flake8 django_resized --ignore=E501
+    flake8: flake8 django_resized --ignore=E501,W504
     django: django-admin test --settings=django_resized.tests.settings {posargs}


### PR DESCRIPTION
Also:
 - remove legacy `super(Class, self)` usage
 - replace `sys.stderr` with `warnings`
 - update classifiers
 - turn "comment string" into proper comments